### PR TITLE
fix(Makefile): fix to support correct mixin versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIXIN = helm3
-PKG = get.porter.sh/mixin/$(MIXIN)
+PKG = github.com/MChorfa/porter-$(MIXIN)
 SHELL = bash
 
 GO = GO111MODULE=on go


### PR DESCRIPTION
* Updates the pkg path such that mixin version data is correctly injected into binaries

Before:

```
 $ ~/.porter/mixins/helm3/helm3 version
helm3  () by Mohamed Chorfa
```

After:

```
 $ ~/.porter/mixins/helm3/helm3 version
helm3 v0.1.4-3-g1df8435 (1df8435) by Mohamed Chorfa
```