### PR TITLE
Change atom references to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ appropriate helm command based on which action it is included within: `install`,
 ### Install or Upgrade
 
 ```shell
-porter mixin install helm3 --feed-url https://mchorfa.github.com/porter-helm3/atom.xml
+porter mixin install helm3 --feed-url https://mchorfa.github.io/porter-helm3/atom.xml
 ```
 
 ### Mixin Configuration

--- a/build/atom-template.xml
+++ b/build/atom-template.xml
@@ -2,7 +2,7 @@
     <id>https://github.com/MChorfa/porter-helm3</id>
     <title>Porter Helm3 Mixin</title>
     <updated>{{Updated}}</updated>
-    <link rel="self" href="https://mchorfa.github.com/porter-helm3/atom.xml"/>
+    <link rel="self" href="https://mchorfa.github.io/porter-helm3/atom.xml"/>
     <author>
         <name>Mohamed chorfa</name>
         <uri>https://github.com/MChorfa/porter-helm3</uri>

--- a/docs/atom.xml
+++ b/docs/atom.xml
@@ -2,7 +2,7 @@
     <id>https://github.com/MChorfa/porter-helm3</id>
     <title>Porter Helm3 Mixin</title>
     <updated>2020-10-25T03:27:07Z</updated>
-    <link rel="self" href="https://mchorfa.github.com/porter-helm3/atom.xml"/>
+    <link rel="self" href="https://mchorfa.github.io/porter-helm3/atom.xml"/>
     <author>
         <name>Mohamed chorfa</name>
         <uri>https://github.com/MChorfa/porter-helm3</uri>


### PR DESCRIPTION
Github no longer redirects <subdomain>.github.com to <subdomain>.github.io which means that the references provided in the README and used in the Atom file itself no longer work.

Additional explanation: https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/

Fixes #19 