### PR TITLE
Helm3 oci support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ bin/porter$(FILE_EXT):
 
 install:
 	# @porter mixin uninstall $(MIXIN)
-	mkdir -p $(PORTER_HOME)/mixins/$(MIXIN)
+	mkdir -p $(PORTER_HOME)/mixins/$(MIXIN)/runtimes/
 	install $(BINDIR)/$(MIXIN)$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)$(FILE_EXT)
-	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)-runtime$(FILE_EXT)
+	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/runtimes/$(MIXIN)-runtime$(FILE_EXT)
 	# @porter mixin list
 clean: clean-packr
 	-rm -fr bin/

--- a/pkg/helm3/helm3.go
+++ b/pkg/helm3/helm3.go
@@ -3,7 +3,9 @@ package helm3
 
 import (
 	"bufio"
+	"fmt"
 	"io/ioutil"
+	"os/exec"
 	"strings"
 
 	"get.porter.sh/porter/pkg/context"
@@ -40,6 +42,26 @@ func New() *Mixin {
 		HelmClientPlatfrom:     defaultClientPlatfrom,
 		HelmClientArchitecture: defaultClientArchitecture,
 	}
+}
+
+func (m *Mixin) RunCmd(cmd *exec.Cmd, printCmd bool) error {
+	cmd.Stdout = m.Out
+	cmd.Stderr = m.Err
+
+	prettyCmd := "obfuscated cmd call"
+	if printCmd {
+		// format the command with all arguments
+		prettyCmd = fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+		fmt.Fprintln(m.Out, prettyCmd)
+	}
+
+	// Here where really the command get executed
+	err := cmd.Start()
+	// Exit on error
+	if err != nil {
+		return fmt.Errorf("could not execute command, %s: %s", prettyCmd, err)
+	}
+	return cmd.Wait()
 }
 
 func (m *Mixin) getPayloadData() ([]byte, error) {

--- a/pkg/helm3/install.go
+++ b/pkg/helm3/install.go
@@ -38,6 +38,19 @@ type RegistryAuthArguments struct {
 	Password string `yaml:"password"`
 }
 
+func (step *InstallStep) GetChart() string {
+	return step.Chart
+}
+func (step *InstallStep) GetRegistryUsername() string {
+	return step.RegistryAuth.Username
+}
+func (step *InstallStep) GetRegistryPassword() string {
+	return step.RegistryAuth.Password
+}
+func (step *InstallStep) GetOptionalVersion() string {
+	return step.Version
+}
+
 func (m *Mixin) Install() error {
 
 	payload, err := m.getPayloadData()
@@ -60,14 +73,14 @@ func (m *Mixin) Install() error {
 	}
 	step := action.Steps[0]
 
-	isOciInstall := IsOciInstall(step)
+	isOciInstall := IsOciInstall(&step)
 
 	if isOciInstall {
 		fmt.Fprintln(m.Out, "OCI install detected.")
 
-		LoginToOciRegistryIfNecessary(step, m)
-		PullChartFromOciRegistry(step, m)
-		newChartName, err := ExportOciChartToTempPath(step, m)
+		LoginToOciRegistryIfNecessary(&step, m)
+		PullChartFromOciRegistry(&step, m)
+		newChartName, err := ExportOciChartToTempPath(&step, m)
 
 		if err != nil {
 			return err
@@ -124,7 +137,7 @@ func (m *Mixin) Install() error {
 	}
 
 	if isOciInstall {
-		err = RemoveLocalOciExport(step, m)
+		err = RemoveLocalOciExport(&step, m)
 	}
 	return err
 }

--- a/pkg/helm3/oci_helpers.go
+++ b/pkg/helm3/oci_helpers.go
@@ -1,0 +1,109 @@
+package helm3
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var ociChartRegex *regexp.Regexp = regexp.MustCompile(`oci:\/\/([^:/]+)\/([^:]+)(:([^:]+))?`)
+
+func IsOciInstall(step InstallStep) bool {
+	return ociChartRegex.MatchString(step.Chart)
+}
+
+// Only call this function if IsOciInstall == true
+func LoginToOciRegistryIfNecessary(step InstallStep, m *Mixin) error {
+	if (step.RegistryAuth.Username == "" && step.RegistryAuth.Password != "") ||
+		(step.RegistryAuth.Username != "" && step.RegistryAuth.Password == "") {
+		return fmt.Errorf("either password or username is empty but not both")
+	}
+
+	subGroups := ociChartRegex.FindStringSubmatch(step.Chart)
+
+	registryUrl := subGroups[1]
+
+	cmd := m.NewCommand(
+		"helm3",
+		"registry",
+		"login",
+		registryUrl)
+
+	if step.RegistryAuth.Username != "" && step.RegistryAuth.Password != "" {
+		cmd.Args = append(cmd.Args,
+			"-u",
+			step.RegistryAuth.Username,
+			"-p",
+			step.RegistryAuth.Password)
+	}
+
+	return m.RunCmd(cmd, false)
+}
+
+// Only call this function if IsOciInstall == true
+func GetFullOciResourceName(step InstallStep) string {
+	subGroups := ociChartRegex.FindStringSubmatch(step.Chart)
+
+	fullOciResourceName := subGroups[1] + "/" + subGroups[2]
+	tag := ":" + subGroups[4]
+	if subGroups[4] == "" {
+		tag = ":" + step.Version
+	}
+	fullOciResourceName = fullOciResourceName + tag
+	return fullOciResourceName
+}
+
+// Only call this function if IsOciInstall == true
+func PullChartFromOciRegistry(step InstallStep, m *Mixin) error {
+	cmd := m.NewCommand(
+		"helm3",
+		"chart",
+		"pull",
+		GetFullOciResourceName(step))
+
+	return m.RunCmd(cmd, true)
+}
+
+// Only call this function if IsOciInstall == true
+func ExportOciChartToTempPath(step InstallStep, m *Mixin) (string, error) {
+	tempChartPath := "/tmp/"
+	cmd := m.NewCommand(
+		"helm3",
+		"chart",
+		"export",
+		GetFullOciResourceName(step),
+		"--destination",
+		tempChartPath)
+
+	cmd.Stderr = m.Err
+
+	// format the command with all arguments
+	prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	fmt.Fprintln(m.Out, prettyCmd)
+
+	// Here where really the command get executed
+	output, err := cmd.Output()
+	m.Out.Write(output)
+	// Exit on error
+	if err != nil {
+		return "", fmt.Errorf("could not execute command, %s: %s", prettyCmd, err)
+	}
+
+	storagePathRegex := regexp.MustCompile(`Exported chart to (.*)`)
+	subGroups := storagePathRegex.FindStringSubmatch(string(output))
+
+	if len(subGroups) == 0 || subGroups[1] == "" {
+		return "", fmt.Errorf("could not extract export path using regex %s", storagePathRegex.String())
+	}
+
+	return subGroups[1], nil
+}
+
+// Only call this function if IsOciInstall == true
+func RemoveLocalOciExport(step InstallStep, m *Mixin) error {
+	cmd := m.NewCommand(
+		"rm",
+		"-rf",
+		step.Chart)
+	return m.RunCmd(cmd, true)
+}


### PR DESCRIPTION
Hi,

this PR adds helm3 OCI support for this mixin. To allow private registries, I've added a registry auth functionality. I know that authentication is also a WIP for helm-repositories so there might be some requirement to discuss this functionality. Because the authentication information should come from porter's credentials feature I couldn't add the auth information to the mixins configuration section. I've rather added a new step's configuration section registryAuth. This also means that no changes to the mixin's configuration section were required.

An example configuration would look like this:

```
install:
  - helm3:
      description: "Install"
      name: test-chart
      chart: oci://registry.helm.domain.com/charts/test-chart
      version: v1.0.0
      namespace: default
      replace: true
      registryAuth:
        username: "john"
        password: "1234"

upgrade:

uninstall:
  - helm3:
      description: "Remove all releases"
      purge: true
      releases:
        - test-chart
```

The mixing is now recognizing OCI chart links by the `oci://` which is also used within helm's Chart.yaml when specifying dependencies. The chart name might contain the tag name, but it's optional and if not specified, the version of the chart will be used.

E.g.

```
install:
   helm3:
      chart: oci://registry.helm.domain.com/charts/test-chart # This will pull oci://registry.helm.domain.com/charts/test-chart:v1.0.0
      version: v1.0.0

----

install:
   helm3:
      chart: oci://registry.helm.domain.com/charts/test-chart:latest # but this will pull oci://registry.helm.domain.com/charts/test-chart:latest
      version: v1.0.0
```

Let me know what you think,

BR Kai