### PR TITLE
Fix upsert flag

### DIFF
--- a/pkg/helm3/install.go
+++ b/pkg/helm3/install.go
@@ -29,7 +29,7 @@ type InstallArguments struct {
 	Set       map[string]string `yaml:"set"`
 	Values    []string          `yaml:"values"`
 	Devel     bool              `yaml:"devel`
-	UpSert    bool              `yaml:"devel`
+	UpSert    bool              `yaml:"upsert`
 	Wait      bool              `yaml:"wait"`
 }
 


### PR DESCRIPTION
The upsert flag was mapped to the wrong yaml key, which prevented anyone from using it.

Fixes #16
