### PR TITLE
Install kubectl

### DIFF
--- a/pkg/helm3/build.go
+++ b/pkg/helm3/build.go
@@ -81,6 +81,8 @@ func (m *Mixin) Build() error {
 		m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture)
 	fmt.Fprintf(m.Out, "\nRUN tar -xvf helm3.tar.gz && rm helm3.tar.gz")
 	fmt.Fprintf(m.Out, "\nRUN mv linux-amd64/helm /usr/local/bin/helm3")
+	fmt.Fprintf(m.Out, "\nRUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl &&\\")
+	fmt.Fprintf(m.Out, "\n    mv kubectl /usr/local/bin && chmod a+x /usr/local/bin/kubectl")
 
 	if len(input.Config.Repositories) > 0 {
 		// Go through repositories

--- a/pkg/helm3/build_test.go
+++ b/pkg/helm3/build_test.go
@@ -19,7 +19,9 @@ func TestMixin_Build(t *testing.T) {
 	buildOutput := `RUN apt-get update && apt-get install -y curl
 RUN curl https://get.helm.sh/helm-%s-%s-%s.tar.gz --output helm3.tar.gz
 RUN tar -xvf helm3.tar.gz && rm helm3.tar.gz
-RUN mv linux-amd64/helm /usr/local/bin/helm3`
+RUN mv linux-amd64/helm /usr/local/bin/helm3
+RUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl &&\
+    mv kubectl /usr/local/bin && chmod a+x /usr/local/bin/kubectl`
 
 	t.Run("build with a valid config", func(t *testing.T) {
 		b, err := ioutil.ReadFile("testdata/build-input-with-valid-config.yaml")


### PR DESCRIPTION
Reading outputs requires that kubectl is on the PATH. Until we rewrite output retrieval to use the k8s library directly, kubectl needs to be installed by the helm mixin.

Fixes #27 