### PR TITLE
Support flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ install:
       wait: BOOL # default true
       noHooks: BOOL # disable pre/post upgrade hooks (default false)
       skipCrds: BOOL # if set, no CRDs will be installed (default false)
+      timeout:  DURATION # time to wait for any individual Kubernetes operation
+      debug: BOOL # enable verbose output (default false)
       set:
         VAR1: VALUE1
         VAR2: VALUE2
@@ -72,6 +74,8 @@ upgrade:
       wait: BOOL # default true
       noHooks: BOOL # disable pre/post upgrade hooks (default false)
       skipCrds: BOOL # if set, no CRDs will be installed (default false)
+      timeout:  DURATION # time to wait for any individual Kubernetes operation
+      debug: BOOL # enable verbose output (default false)
       set:
         VAR1: VALUE1
         VAR2: VALUE2
@@ -91,8 +95,10 @@ uninstall:
       releases:
         - RELEASE_NAME1
         - RELEASE_NAME2
-      wait: BOOL # default false
+      wait: BOOL # default false, if set It will wait for as long as --timeout
       noHooks: BOOL # prevent hooks from running during uninstallation
+      timeout:  DURATION # time to wait for any individual Kubernetes operation
+      debug: BOOL # enable verbose output (default false)
 ```
 
 #### Outputs

--- a/pkg/helm3/execute_test.go
+++ b/pkg/helm3/execute_test.go
@@ -59,7 +59,7 @@ func TestMixin_UnmarshalExecuteLoginRegistryStep(t *testing.T) {
 		builder.Flag{Name: "u", Values: []string{"myuser"}},
 	}
 
-	assert.Equal(t, wantFlags, step.Flags)
+	assert.EqualValues(t, wantFlags, step.Flags)
 }
 
 func TestMixin_UnmarshalExecuteLoginRegistryInsecureStep(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMixin_UnmarshalExecuteLoginRegistryInsecureStep(t *testing.T) {
 		builder.Flag{Name: "u", Values: []string{"myuser"}},
 	}
 
-	assert.Equal(t, wantFlags, step.Flags)
+	assert.EqualValues(t, wantFlags, step.Flags)
 }
 
 func TestMixin_Execute_Login_Registry(t *testing.T) {

--- a/pkg/helm3/install.go
+++ b/pkg/helm3/install.go
@@ -34,6 +34,8 @@ type InstallArguments struct {
 	Values    []string          `yaml:"values"`
 	Version   string            `yaml:"version"`
 	Wait      bool              `yaml:"wait"`
+	Timeout   string            `yaml:"timeout"`
+	Debug     bool              `yaml:"debug"`
 }
 
 func (m *Mixin) Install() error {
@@ -92,6 +94,13 @@ func (m *Mixin) Install() error {
 
 	if step.Repo != "" && step.Username != "" && step.Password != "" {
 		cmd.Args = append(cmd.Args, "--repo", step.Repo, "--username", step.Username, "--password", step.Password)
+	}
+
+	if step.Timeout != "" {
+		cmd.Args = append(cmd.Args, "--timeout", step.Timeout)
+	}
+	if step.Debug {
+		cmd.Args = append(cmd.Args, "--debug")
 	}
 	// This will ensure the installation process deletes the installation on failure.
 	cmd.Args = append(cmd.Args, "--atomic")

--- a/pkg/helm3/install_test.go
+++ b/pkg/helm3/install_test.go
@@ -138,6 +138,22 @@ func TestMixin_Install(t *testing.T) {
 				},
 			},
 		},
+		{
+			expectedCommand: fmt.Sprintf(`%s %s %s %s %s`, baseInstall, baseValues, `--timeout 600 --debug`, baseAddFlags, baseSetArgs),
+			installStep: InstallStep{
+				InstallArguments: InstallArguments{
+					Step:      Step{Description: "Install Foo"},
+					Namespace: namespace,
+					Name:      name,
+					Chart:     chart,
+					Version:   version,
+					Set:       setArgs,
+					Values:    values,
+					Timeout:   "600",
+					Debug:     true,
+				},
+			},
+		},
 	}
 
 	defer os.Unsetenv(test.ExpectedCommandEnv)

--- a/pkg/helm3/schema/schema.json
+++ b/pkg/helm3/schema/schema.json
@@ -42,6 +42,13 @@
             "wait":{
               "type":"boolean"
             },
+            "timeout":{
+              "type":"string"
+            },
+            "debug":{
+              "type":"boolean",
+              "default":false
+            },
             "devel":{
               "type":"boolean"
             },
@@ -110,6 +117,13 @@
               "default":false
             },
             "wait":{
+              "type":"boolean",
+              "default":false
+            },
+            "timeout":{
+              "type":"string"
+            },
+            "debug":{
               "type":"boolean",
               "default":false
             },
@@ -183,6 +197,13 @@
               "default":false
             },
             "noHooks":{
+              "type":"boolean",
+              "default":false
+            },
+            "timeout":{
+              "type":"string"
+            },
+            "debug":{
               "type":"boolean",
               "default":false
             }

--- a/pkg/helm3/testdata/schema.json
+++ b/pkg/helm3/testdata/schema.json
@@ -42,6 +42,13 @@
             "wait":{
               "type":"boolean"
             },
+            "timeout":{
+              "type":"string"
+            },
+            "debug":{
+              "type":"boolean",
+              "default":false
+            },
             "devel":{
               "type":"boolean"
             },
@@ -110,6 +117,13 @@
               "default":false
             },
             "wait":{
+              "type":"boolean",
+              "default":false
+            },
+            "timeout":{
+              "type":"string"
+            },
+            "debug":{
               "type":"boolean",
               "default":false
             },
@@ -183,6 +197,13 @@
               "default":false
             },
             "noHooks":{
+              "type":"boolean",
+              "default":false
+            },
+            "timeout":{
+              "type":"string"
+            },
+            "debug":{
               "type":"boolean",
               "default":false
             }

--- a/pkg/helm3/uninstall_test.go
+++ b/pkg/helm3/uninstall_test.go
@@ -73,6 +73,19 @@ func TestMixin_Uninstall(t *testing.T) {
 				},
 			},
 		},
+		{
+			expectedCommand: "helm3 uninstall foo --namespace my-namespace --no-hooks --timeout 600 --debug",
+			uninstallStep: UninstallStep{
+				UninstallArguments: UninstallArguments{
+					Step:      Step{Description: "Uninstall Foo"},
+					Releases:  releases,
+					Namespace: namespace,
+					NoHooks:   noHooks,
+					Timeout:   "600",
+					Debug:     true,
+				},
+			},
+		},
 	}
 
 	defer os.Unsetenv(test.ExpectedCommandEnv)

--- a/pkg/helm3/upgrade.go
+++ b/pkg/helm3/upgrade.go
@@ -37,6 +37,8 @@ type UpgradeArguments struct {
 	SkipCrds    bool              `yaml:"skipcrds`
 	Password    string            `yaml:"password"`
 	Username    string            `yaml:"username"`
+	Timeout     string            `yaml:"timeout"`
+	Debug       bool              `yaml:"debug"`
 }
 
 // Upgrade issues a helm upgrade command for a release using the provided UpgradeArguments
@@ -87,10 +89,19 @@ func (m *Mixin) Upgrade() error {
 		cmd.Args = append(cmd.Args, "--values", v)
 	}
 
+	if step.Timeout != "" {
+		cmd.Args = append(cmd.Args, "--timeout", step.Timeout)
+	}
+
+	if step.Debug {
+		cmd.Args = append(cmd.Args, "--debug")
+	}
+
 	// This will upgrade process rolls back changes made in case of failed upgrade.
 	cmd.Args = append(cmd.Args, "--atomic")
 	// This will ensure the creation of the release namespace if not present.
 	cmd.Args = append(cmd.Args, "--create-namespace")
+
 	cmd.Args = HandleSettingChartValuesForUpgrade(step, cmd)
 
 	cmd.Stdout = m.Out

--- a/pkg/helm3/upgrade_test.go
+++ b/pkg/helm3/upgrade_test.go
@@ -120,6 +120,22 @@ func TestMixin_Upgrade(t *testing.T) {
 				},
 			},
 		},
+		{
+			expectedCommand: fmt.Sprintf(`%s %s %s %s %s`, baseUpgrade, baseValues, `--timeout 600 --debug`, baseAddFlags, baseSetArgs),
+			upgradeStep: UpgradeStep{
+				UpgradeArguments: UpgradeArguments{
+					Step:      Step{Description: "Upgrade Foo"},
+					Namespace: namespace,
+					Name:      name,
+					Chart:     chart,
+					Version:   version,
+					Set:       setArgs,
+					Values:    values,
+					Timeout:   "600",
+					Debug:     true,
+				},
+			},
+		},
 	}
 
 	defer os.Unsetenv(test.ExpectedCommandEnv)


### PR DESCRIPTION
Add support for `--timeout` and `debug` flags to allow setting the timeout for a given Porter action like `Install`, `Upgrade`, or `Uninstall`

Closes #37, #30 