### PR TITLE
Work with nonroot invocation images

### DIFF
--- a/example/porter.yaml
+++ b/example/porter.yaml
@@ -12,7 +12,7 @@ registry: getporter
 
 credentials:
 - name: kubeconfig
-  path: /root/.kube/config
+  path: /home/nonroot/.kube/config
 - name: helm-registry-password
   env: HELM_REGISTRY_PASSWORD
 

--- a/pkg/helm3/build_test.go
+++ b/pkg/helm3/build_test.go
@@ -22,7 +22,8 @@ RUN curl https://get.helm.sh/helm-%s-%s-%s.tar.gz --output helm3.tar.gz
 RUN tar -xvf helm3.tar.gz && rm helm3.tar.gz
 RUN mv linux-amd64/helm /usr/local/bin/helm3
 RUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl &&\
-    mv kubectl /usr/local/bin && chmod a+x /usr/local/bin/kubectl`
+    mv kubectl /usr/local/bin && chmod a+x /usr/local/bin/kubectl
+`
 
 	t.Run("build with a valid config", func(t *testing.T) {
 		b, err := ioutil.ReadFile("testdata/build-input-with-valid-config.yaml")
@@ -36,9 +37,11 @@ RUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1
 		require.NoError(t, err, "build failed")
 
 		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture) +
-			"\nRUN helm3 repo add stable kubernetes-charts" +
-			"\nRUN helm3 repo update"
-
+			`USER ${BUNDLE_USER}
+RUN helm3 repo add stable kubernetes-charts
+RUN helm3 repo update
+USER root
+`
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)
 	})
@@ -55,10 +58,13 @@ RUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1
 		require.NoError(t, err, "build failed")
 
 		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture) +
-			"\nRUN helm3 repo add harbor https://helm.getharbor.io" +
-			"\nRUN helm3 repo add jetstack https://charts.jetstack.io" +
-			"\nRUN helm3 repo add stable kubernetes-charts" +
-			"\nRUN helm3 repo update"
+			`USER ${BUNDLE_USER}
+RUN helm3 repo add harbor https://helm.getharbor.io
+RUN helm3 repo add jetstack https://charts.jetstack.io
+RUN helm3 repo add stable kubernetes-charts
+RUN helm3 repo update
+USER root
+`
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)
 	})
@@ -74,7 +80,10 @@ RUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1
 		err = m.Build()
 		require.NoError(t, err, "build failed")
 		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture) +
-			"\nRUN helm3 repo update"
+			`USER ${BUNDLE_USER}
+RUN helm3 repo update
+USER root
+`
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)
 	})

--- a/pkg/helm3/execute.go
+++ b/pkg/helm3/execute.go
@@ -30,7 +30,7 @@ func (m *Mixin) Execute() error {
 		return errors.Wrapf(err, "invocation of action %s failed", action)
 	}
 
-	kubeClient, err := m.getKubernetesClient("/root/.kube/config")
+	kubeClient, err := m.getKubernetesClient()
 	if err != nil {
 		return errors.Wrap(err, "couldn't get kubernetes client")
 	}

--- a/pkg/helm3/helm3.go
+++ b/pkg/helm3/helm3.go
@@ -81,6 +81,6 @@ func (m *Mixin) ValidatePayload(b []byte) error {
 	return nil
 }
 
-func (m *Mixin) getKubernetesClient(kubeconfig string) (k8s.Interface, error) {
-	return m.ClientFactory.GetClient(kubeconfig)
+func (m *Mixin) getKubernetesClient() (k8s.Interface, error) {
+	return m.ClientFactory.GetClient()
 }

--- a/pkg/helm3/helpers.go
+++ b/pkg/helm3/helpers.go
@@ -18,7 +18,7 @@ type TestMixin struct {
 type testKubernetesFactory struct {
 }
 
-func (t *testKubernetesFactory) GetClient(configPath string) (kubernetes.Interface, error) {
+func (t *testKubernetesFactory) GetClient() (kubernetes.Interface, error) {
 	return testclient.NewSimpleClientset(), nil
 }
 

--- a/pkg/helm3/install.go
+++ b/pkg/helm3/install.go
@@ -45,7 +45,7 @@ func (m *Mixin) Install() error {
 		return err
 	}
 
-	kubeClient, err := m.getKubernetesClient("/root/.kube/config")
+	kubeClient, err := m.getKubernetesClient()
 	if err != nil {
 		return errors.Wrap(err, "couldn't get kubernetes client")
 	}

--- a/pkg/helm3/upgrade.go
+++ b/pkg/helm3/upgrade.go
@@ -48,7 +48,7 @@ func (m *Mixin) Upgrade() error {
 		return err
 	}
 
-	kubeClient, err := m.getKubernetesClient("/root/.kube/config")
+	kubeClient, err := m.getKubernetesClient()
 	if err != nil {
 		return errors.Wrap(err, "couldn't get kubernetes client")
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -13,7 +13,7 @@ import (
 
 // ClientFactory is an interface that knows how to create Kubernetes Clients
 type ClientFactory interface {
-	GetClient(configPath string) (k8s.Interface, error)
+	GetClient() (k8s.Interface, error)
 }
 
 // ClientFactory struct
@@ -21,9 +21,8 @@ type clientFactory struct {
 }
 
 // GetClient: Read the config and create Kubernetes Clients
-func (f *clientFactory) GetClient(configPath string) (k8s.Interface, error) {
-
-	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+func (f *clientFactory) GetClient() (k8s.Interface, error) {
+	config, err := clientcmd.DefaultClientConfig.ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't build kubernetes config: %s", err)
 	}


### PR DESCRIPTION
This updates the helm3 mixin for the upcoming change in Porter (v1) where bundles will run as the nonroot user instead of root. Starting in v1.0.0-alpha.12, porter injects files into the bundle differently, owned by a nonroot user and the root group. Previously the kubeconfig creds were injected to /root/.kube/config by most bundles. That location isn't accessible when running as a nonroot user. Any kubeconfig credentials should be updated to be placed in /home/nonroot/.kube/config or another location in /cnab/app that the nonroot user will have access to while exporting KUBECONFIG so it can be located by kubectl/helm.

I have updated helm3 to locate kubeconfig using the same logic as kubectl, using the KUBECONFIG environment variable, then $HOME/.kube/config.

It also switches the user that some commands run as during build. Installing helm should run as root, but initializing the helm repositories should run as the same user that the container runs as, nonroot so that the .helm config directory is located in /home/nonroot where it can be read when the bundle is executed.