### PR TITLE
Define mixin configuration schema

### DIFF
--- a/pkg/helm3/build.go
+++ b/pkg/helm3/build.go
@@ -25,7 +25,7 @@ type BuildInput struct {
 // mixins:
 // - helm3:
 // 	  clientVersion: v3.8.2
-// 	  clientPlatfrom: linux
+// 	  clientPlatform: linux
 // 	  clientArchitecture: amd64 | arm64 | arm | i386
 //	  repositories:
 //	    stable:
@@ -33,9 +33,9 @@ type BuildInput struct {
 
 type MixinConfig struct {
 	ClientVersion      string `yaml:"clientVersion,omitempty"`
-	ClientPlatfrom     string `yaml:"clientPlatfrom,omitempty"`
 	ClientArchitecture string `yaml:"clientArchitecture,omitempty"`
 	Repositories       map[string]Repository
+	ClientPlatform     string                `yaml:"clientPlatform,omitempty"`
 }
 
 type Repository struct {
@@ -69,8 +69,8 @@ func (m *Mixin) Build(ctx context.Context) error {
 		m.HelmClientVersion = suppliedClientVersion
 	}
 
-	if input.Config.ClientPlatfrom != "" {
-		m.HelmClientPlatfrom = input.Config.ClientPlatfrom
+	if input.Config.ClientPlatform != "" {
+		m.HelmClientPlatform = input.Config.ClientPlatform
 	}
 
 	if input.Config.ClientArchitecture != "" {
@@ -80,7 +80,7 @@ func (m *Mixin) Build(ctx context.Context) error {
 	fmt.Fprint(m.Out, "ENV HELM_EXPERIMENTAL_OCI=1")
 	fmt.Fprintf(m.Out, "\nRUN apt-get update && apt-get install -y curl")
 	fmt.Fprintf(m.Out, "\nRUN curl https://get.helm.sh/helm-%s-%s-%s.tar.gz --output helm3.tar.gz",
-		m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture)
+		m.HelmClientVersion, m.HelmClientPlatform, m.HelmClientArchitecture)
 	fmt.Fprintf(m.Out, "\nRUN tar -xvf helm3.tar.gz && rm helm3.tar.gz")
 	fmt.Fprintf(m.Out, "\nRUN mv linux-amd64/helm /usr/local/bin/helm3")
 	fmt.Fprintf(m.Out, "\nRUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl &&\\")

--- a/pkg/helm3/build.go
+++ b/pkg/helm3/build.go
@@ -32,10 +32,10 @@ type BuildInput struct {
 //		  url: "https://charts.helm.sh/stable"
 
 type MixinConfig struct {
-	ClientVersion      string `yaml:"clientVersion,omitempty"`
-	ClientArchitecture string `yaml:"clientArchitecture,omitempty"`
-	Repositories       map[string]Repository
+	ClientVersion      string                `yaml:"clientVersion,omitempty"`
 	ClientPlatform     string                `yaml:"clientPlatform,omitempty"`
+	ClientArchitecture string                `yaml:"clientArchitecture,omitempty"`
+	Repositories       map[string]Repository `yaml:"repositories,omitempty"`
 }
 
 type Repository struct {

--- a/pkg/helm3/build_test.go
+++ b/pkg/helm3/build_test.go
@@ -38,7 +38,7 @@ RUN curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1
 		err = m.Build(ctx)
 		require.NoError(t, err, "build failed")
 
-		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture) +
+		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatform, m.HelmClientArchitecture) +
 			`USER ${BUNDLE_USER}
 RUN helm3 repo add stable kubernetes-charts
 RUN helm3 repo update
@@ -59,7 +59,7 @@ USER root
 		err = m.Build(ctx)
 		require.NoError(t, err, "build failed")
 
-		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture) +
+		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatform, m.HelmClientArchitecture) +
 			`USER ${BUNDLE_USER}
 RUN helm3 repo add harbor https://helm.getharbor.io
 RUN helm3 repo add jetstack https://charts.jetstack.io
@@ -81,7 +81,7 @@ USER root
 
 		err = m.Build(ctx)
 		require.NoError(t, err, "build failed")
-		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture) +
+		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatform, m.HelmClientArchitecture) +
 			`USER ${BUNDLE_USER}
 RUN helm3 repo update
 USER root
@@ -100,7 +100,7 @@ USER root
 		m.In = bytes.NewReader(b)
 		err = m.Build(ctx)
 		require.NoError(t, err, "build failed")
-		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatfrom, m.HelmClientArchitecture)
+		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion, m.HelmClientPlatform, m.HelmClientArchitecture)
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)
 	})

--- a/pkg/helm3/helm3.go
+++ b/pkg/helm3/helm3.go
@@ -14,7 +14,7 @@ import (
 )
 
 const defaultClientVersion string = "v3.8.2"
-const defaultClientPlatfrom string = "linux"
+const defaultClientPlatform string = "linux"
 const defaultClientArchitecture string = "amd64"
 
 // Helm is the logic behind the helm mixin
@@ -22,7 +22,7 @@ type Mixin struct {
 	runtime.RuntimeConfig
 	ClientFactory          kubernetes.ClientFactory
 	HelmClientVersion      string
-	HelmClientPlatfrom     string
+	HelmClientPlatform     string
 	HelmClientArchitecture string
 }
 
@@ -32,7 +32,7 @@ func New() *Mixin {
 		RuntimeConfig:          runtime.NewConfig(),
 		ClientFactory:          kubernetes.New(),
 		HelmClientVersion:      defaultClientVersion,
-		HelmClientPlatfrom:     defaultClientPlatfrom,
+		HelmClientPlatform:     defaultClientPlatform,
 		HelmClientArchitecture: defaultClientArchitecture,
 	}
 }

--- a/pkg/helm3/schema/schema.json
+++ b/pkg/helm3/schema/schema.json
@@ -1,6 +1,58 @@
 {
   "$schema":"http://json-schema.org/draft-07/schema#",
   "definitions":{
+    "declaration": {
+      "oneOf": [
+        {
+          "description": "Declare the helm3 mixin without configuration",
+          "type": "string",
+          "enum": ["helm3"]
+        },
+        {"$ref": "#/definitions/config"}
+      ]
+    },
+    "config": {
+      "description": "Declare the helm3 mixin with additional configuration",
+      "type": "object",
+      "properties": {
+        "helm3": {
+          "description": "helm3 mixin configuration",
+          "type": "object",
+          "properties": {
+            "clientVersion": {
+              "description": "Version of helm to install in the bundle",
+              "type": "string"
+            },
+            "clientPlatform": {
+              "description": "Operating system of the helm client to install in the bundle, for example linux",
+              "type": "string"
+            },
+            "clientArchitecture": {
+              "description": "Architecture of the helm client to install in the bundle, for example amd64",
+              "type": "string"
+            },
+            "repositories": {
+              "description": "Helm repositories to initialize in the bundle, keyed by the repository alias",
+              "type": "object",
+              "additionalProperties":{
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "description": "URL of the helm chart repository",
+                    "type": "string"
+                  }
+              },
+              "additionalProperties": false,
+              "required": ["url"]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["helm3"]
+    },
     "installStep":{
       "type":"object",
       "properties":{
@@ -308,13 +360,16 @@
       "items":{
         "$ref":"#/definitions/uninstallStep"
       }
+    },
+    "mixins": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/declaration" }
     }
   },
-  "additionalProperties":{
-    "type":"array",
-    "items":{
-      "$ref":"#/definitions/invokeStep"
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "$ref": "#/definitions/invokeStep"
     }
-  },
-  "additionalProperties":false
+  }
 }

--- a/pkg/helm3/schema_test.go
+++ b/pkg/helm3/schema_test.go
@@ -1,10 +1,12 @@
 package helm3
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"testing"
 
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/ghodss/yaml" // We are not using go-yaml because of serialization problems with jsonschema, don't use this library elsewhere
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,6 +46,7 @@ func TestMixin_ValidateSchema(t *testing.T) {
 		{"invalid property", "testdata/invalid-input.yaml", "Additional property args is not allowed"},
 		{"install", "testdata/uninstall-input.yaml", ""},
 		{"invalid property", "testdata/invalid-input.yaml", "Additional property args is not allowed"},
+		{"mixin config", "testdata/config-input.yaml", ""},
 	}
 
 	for _, tc := range testcases {
@@ -63,10 +66,56 @@ func TestMixin_ValidateSchema(t *testing.T) {
 			if tc.wantError == "" {
 				assert.True(t, result.Valid())
 				assert.Empty(t, result.Errors())
+				// Print out any validation errors
+				for _, err := range result.Errors() {
+					t.Logf("%s", err)
+				}
 			} else {
 				assert.False(t, result.Valid())
 				assert.Contains(t, fmt.Sprintf("%v", result.Errors()), tc.wantError)
 			}
 		})
 	}
+}
+
+func TestMixin_CheckSchema(t *testing.T) {
+	// Long term it would be great to have a helper function in Porter that a mixin can use to check that it meets certain interfaces
+	// check that certain characteristics of the schema that Porter expects are present
+	// Once we have a mixin library, that would be a good place to package up this type of helper function
+	var schemaMap map[string]interface{}
+	err := json.Unmarshal([]byte(schemaDoc), &schemaMap)
+	require.NoError(t, err, "could not unmarshal the schema into a map")
+
+	t.Run("mixin configuration", func(t *testing.T) {
+		// Check that mixin config is defined, and has all the supported fields
+		configSchema, err := jsonpath.Get("$.definitions.config", schemaMap)
+		require.NoError(t, err, "could not find the mixin config schema declaration")
+		_, err = jsonpath.Get("$.properties.helm3.properties.clientVersion", configSchema)
+		require.NoError(t, err, "client version was not included in the mixin config schema")
+		_, err = jsonpath.Get("$.properties.helm3.properties.clientPlatform", configSchema)
+		require.NoError(t, err, "client platform was not included in the mixin config schema")
+		_, err = jsonpath.Get("$.properties.helm3.properties.clientArchitecture", configSchema)
+		require.NoError(t, err, "client architecture was not included in the mixin config schema")
+		repos, err := jsonpath.Get("$.properties.helm3.properties.repositories", configSchema)
+		require.NoError(t, err, "repositories was not included in the mixin config schema")
+		_, err = jsonpath.Get("$.additionalProperties.properties.url", repos)
+		require.NoError(t, err, "repositories did not include a url field in the mixin config schema")
+	})
+
+	// Check that schema are defined for each action
+	actions := []string{"install", "upgrade", "invoke", "uninstall"}
+	for _, action := range actions {
+		t.Run("supports "+action, func(t *testing.T) {
+			actionPath := fmt.Sprintf("$.definitions.%sStep", action)
+			_, err := jsonpath.Get(actionPath, schemaMap)
+			require.NoErrorf(t, err, "could not find the %sStep declaration", action)
+		})
+	}
+
+	// Check that the invoke action is registered
+	additionalSchema, err := jsonpath.Get("$.additionalProperties.items", schemaMap)
+	require.NoError(t, err, "the invoke action was not registered in the schema")
+	require.Contains(t, additionalSchema, "$ref")
+	invokeRef := additionalSchema.(map[string]interface{})["$ref"]
+	require.Equal(t, "#/definitions/invokeStep", invokeRef, "the invoke action was not registered correctly")
 }

--- a/pkg/helm3/testdata/build-input-with-invalid-client-version.yaml
+++ b/pkg/helm3/testdata/build-input-with-invalid-client-version.yaml
@@ -1,8 +1,2 @@
 config:
   clientVersion: v3.8.2.0
-install:
-  - helm3:
-      description: "Install MySQL"
-      name: porter-ci-mysql
-      chart: stable/mysql
-      version: 0.10.2

--- a/pkg/helm3/testdata/build-input-with-invalid-config.yaml
+++ b/pkg/helm3/testdata/build-input-with-invalid-config.yaml
@@ -1,8 +1,3 @@
 config:
   repositories:
-    stable:
-install:
-  - helm3:
-      description: "Install MySQL"
-      chart: stable/mysql
-      version: 0.10.2
+    stable: {}

--- a/pkg/helm3/testdata/build-input-with-supported-client-version.yaml
+++ b/pkg/helm3/testdata/build-input-with-supported-client-version.yaml
@@ -1,8 +1,2 @@
 config:
   clientVersion: v3.8.2
-install:
-  - helm3:
-      description: "Install MySQL"
-      name: porter-ci-mysql
-      chart: stable/mysql
-      version: 0.10.2

--- a/pkg/helm3/testdata/build-input-with-unsupported-client-version.yaml
+++ b/pkg/helm3/testdata/build-input-with-unsupported-client-version.yaml
@@ -1,8 +1,2 @@
 config:
   clientVersion: v2.16.1
-install:
-  - helm3:
-      description: "Install MySQL"
-      name: porter-ci-mysql
-      chart: stable/mysql
-      version: 0.10.2

--- a/pkg/helm3/testdata/build-input-with-valid-config-multi-repos.yaml
+++ b/pkg/helm3/testdata/build-input-with-valid-config-multi-repos.yaml
@@ -6,8 +6,3 @@ config:
       url: "https://charts.jetstack.io"
     harbor:
       url: "https://helm.getharbor.io"
-install:
-  - helm3:
-      description: "Install MySQL"
-      chart: stable/mysql
-      version: 0.10.2

--- a/pkg/helm3/testdata/build-input-with-valid-config.yaml
+++ b/pkg/helm3/testdata/build-input-with-valid-config.yaml
@@ -1,9 +1,7 @@
 config:
+  clientVersion: 3.17.0
+  clientPlatform: linux
+  clientArchitecture: amd64
   repositories:
     stable:
       url: "kubernetes-charts"
-install:
-  - helm3:
-      description: "Install MySQL"
-      chart: stable/mysql
-      version: 0.10.2

--- a/pkg/helm3/testdata/build-input-with-version.yaml
+++ b/pkg/helm3/testdata/build-input-with-version.yaml
@@ -1,6 +1,6 @@
 config:
   clientVersion: v3.8.2
-  clientPlatfrom: linux
+  clientPlatform: linux
   clientArchitecture: amd64
 
 install:

--- a/pkg/helm3/testdata/build-input-with-version.yaml
+++ b/pkg/helm3/testdata/build-input-with-version.yaml
@@ -2,11 +2,3 @@ config:
   clientVersion: v3.8.2
   clientPlatform: linux
   clientArchitecture: amd64
-
-install:
-  - helm3:
-      description: "Install MySQL"
-      name: porter-ci-mysql
-      chart: stable/mysql
-      version: 0.10.2
-

--- a/pkg/helm3/testdata/config-input.yaml
+++ b/pkg/helm3/testdata/config-input.yaml
@@ -1,0 +1,8 @@
+mixins:
+  - helm3:
+      clientVersion: 1.2.3
+      clientPlatform: linux
+      clientArchitecture: amd64
+      repositories:
+        stable:
+          url: "kubernetes-charts"


### PR DESCRIPTION
* Fix spelling of clientPlatform
* Include the json schema for the helm3 mixin config section so that we can get autocomplete and validation support in VS Code when editing a porter.yaml file. See https://github.com/getporter/porter/pull/2290 for the upstream change.